### PR TITLE
Added OverviewScreen and Navigation dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 
 android {
     namespace = "com.example.emptyactivity"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.emptyactivity"
         minSdk = 24
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 
@@ -75,7 +75,9 @@ dependencies {
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material:material")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.navigation:navigation-compose:2.7.4")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/example/emptyactivity/BankDestinations.kt
+++ b/app/src/main/java/com/example/emptyactivity/BankDestinations.kt
@@ -1,0 +1,23 @@
+package com.example.emptyactivity
+
+interface BankDestination {
+    val route: String
+}
+
+object Overview : BankDestination {
+    override val route = "overview"
+}
+
+object Chequing : BankDestination {
+    override val route = "chequing"
+}
+
+object Savings : BankDestination {
+    override val route = "savings"
+}
+
+object Credit : BankDestination {
+    override val route = "credit"
+}
+
+val bankTabRowScreens = listOf(Overview, Chequing, Savings, Credit)

--- a/app/src/main/java/com/example/emptyactivity/MainActivity.kt
+++ b/app/src/main/java/com/example/emptyactivity/MainActivity.kt
@@ -4,28 +4,23 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.example.emptyactivity.components.BankTabRow
 import com.example.emptyactivity.ui.theme.EmptyActivityTheme
 
 val SAMPLE_LIST = mutableListOf<Double>(5.01, 2.4, 6.4, 8.7, 5.9)
@@ -56,66 +51,77 @@ class MainActivity : ComponentActivity() {
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun CJJBankApp() {
+    val navController = rememberNavController()
+    val currentBackStack by navController.currentBackStackEntryAsState()
+    val currentDestination = currentBackStack?.destination
+    val currentScreen = bankTabRowScreens.find { it.route == currentDestination?.route } ?: Overview
+
     Scaffold(
         topBar = {
-            CJJBankAppTopBar()
+            BankTabRow(
+                screens = bankTabRowScreens,
+                onTabSelected = { screen ->
+                    navController.navigateSingleTopTo(screen.route)
+                },
+                currentScreen = currentScreen
+            )
         }
-    ) {
-        contentPadding ->
-
-        Box(modifier = Modifier.padding(contentPadding)) {
-            OverviewScreen()
-        }
+    ) { contentPadding ->
+        BankNavHost(
+            navController = navController,
+            modifier = Modifier.padding(contentPadding)
+        )
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * Date of Retrieval: 2023/11/02
+ * All Nav-related functions and variables are based on the ones in the Rally app from the Navigation codelab.
+ * https://developer.android.com/codelabs/jetpack-compose-navigation
+ */
 @Composable
-fun CJJBankAppTopBar(modifier: Modifier = Modifier) {
-    CenterAlignedTopAppBar(
-        title = {
-            Row {
-                Text(
-                    text = "OVERVIEW",
-                    style = MaterialTheme.typography.labelLarge,
-                )
-                Spacer(modifier = Modifier.padding(13.dp))
-                Text(
-                    text = "CHEQUING",
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Spacer(modifier = Modifier.padding(13.dp))
-                Text(text = "SAVINGS",
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Spacer(modifier = Modifier.padding(13.dp))
-                Text(text = "CREDIT",
-                    style = MaterialTheme.typography.labelLarge
-                )
-            }
-        }
-    )
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
+fun BankNavHost(
+    navController: NavHostController,
+    modifier: Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = Overview.route,
         modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    EmptyActivityTheme {
-        Greeting("Android")
+    ) {
+        composable(route = Overview.route) {
+            OverviewScreen(
+                onClickViewChequingAccount = {
+                    navController.navigateSingleTopTo(Chequing.route)
+                }
+            )
+        }
     }
 }
+
+fun NavHostController.navigateSingleTopTo(route: String) =
+    this.navigate(route) {
+        popUpTo(
+            this@navigateSingleTopTo.graph.findStartDestination().id
+        ) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
 
 @Preview
 @Composable
 fun CJJBankAppPreview()
 {
     CJJBankApp()
+}
+
+@Preview
+@Composable
+fun CJJBankAppDarkModePreview()
+{
+    EmptyActivityTheme(darkTheme = true) {
+        CJJBankApp()
+    }
 }

--- a/app/src/main/java/com/example/emptyactivity/MainActivity.kt
+++ b/app/src/main/java/com/example/emptyactivity/MainActivity.kt
@@ -1,15 +1,31 @@
 package com.example.emptyactivity
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.example.emptyactivity.ui.theme.EmptyActivityTheme
 
 val SAMPLE_LIST = mutableListOf<Double>(5.01, 2.4, 6.4, 8.7, 5.9)
@@ -25,15 +41,60 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
 
-                   AccountScreen();
+                   //AccountScreen();
                    // Greeting("Android")
                     // WithdrawalScreen().ShowWithdrawalScreen()
                     // CadenPage().MainPage(breathList = SAMPLE_LIST)
-
+                    CJJBankApp()
                 }
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun CJJBankApp() {
+    Scaffold(
+        topBar = {
+            CJJBankAppTopBar()
+        }
+    ) {
+        contentPadding ->
+
+        Box(modifier = Modifier.padding(contentPadding)) {
+            OverviewScreen()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CJJBankAppTopBar(modifier: Modifier = Modifier) {
+    CenterAlignedTopAppBar(
+        title = {
+            Row {
+                Text(
+                    text = "OVERVIEW",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Spacer(modifier = Modifier.padding(13.dp))
+                Text(
+                    text = "CHEQUING",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Spacer(modifier = Modifier.padding(13.dp))
+                Text(text = "SAVINGS",
+                    style = MaterialTheme.typography.labelLarge
+                )
+                Spacer(modifier = Modifier.padding(13.dp))
+                Text(text = "CREDIT",
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+        }
+    )
 }
 
 @Composable
@@ -50,4 +111,11 @@ fun GreetingPreview() {
     EmptyActivityTheme {
         Greeting("Android")
     }
+}
+
+@Preview
+@Composable
+fun CJJBankAppPreview()
+{
+    CJJBankApp()
 }

--- a/app/src/main/java/com/example/emptyactivity/OverviewScreen.kt
+++ b/app/src/main/java/com/example/emptyactivity/OverviewScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -23,19 +22,25 @@ import com.example.emptyactivity.ui.theme.EmptyActivityTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OverviewScreen() {
+fun OverviewScreen(
+    onClickViewChequingAccount: () -> Unit = {}
+) {
     Column(
         modifier = Modifier
             .padding(13.dp)
             .semantics { contentDescription = "Overview Screen" }
             .verticalScroll(rememberScrollState())
     ) {
-        ChequingAccountCard()
+        ChequingAccountCard(
+            onClickViewAccount = onClickViewChequingAccount
+        )
     }
 }
 
 @Composable
-fun ChequingAccountCard() {
+fun ChequingAccountCard(
+    onClickViewAccount: () -> Unit
+) {
 
     val chequingAccount: Account? = chequingAccounts.find { it.number == 12345 }
     val balance = chequingAccount?.balance
@@ -56,7 +61,7 @@ fun ChequingAccountCard() {
         TextButton(
             modifier = Modifier
                 .fillMaxWidth(),
-            onClick = { /*TODO*/ }
+            onClick = onClickViewAccount
         ) {
             Text(
                 text = "VIEW",
@@ -75,7 +80,7 @@ fun OverviewScreenPreview()
 
 @Preview
 @Composable
-fun ChocolateShopDarkModePreview() {
+fun OverviewScreenDarkModePreview() {
     EmptyActivityTheme(darkTheme = true) {
         OverviewScreen()
     }

--- a/app/src/main/java/com/example/emptyactivity/OverviewScreen.kt
+++ b/app/src/main/java/com/example/emptyactivity/OverviewScreen.kt
@@ -1,0 +1,82 @@
+package com.example.emptyactivity
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.emptyactivity.data.Account
+import com.example.emptyactivity.data.chequingAccounts
+import com.example.emptyactivity.ui.theme.EmptyActivityTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OverviewScreen() {
+    Column(
+        modifier = Modifier
+            .padding(13.dp)
+            .semantics { contentDescription = "Overview Screen" }
+            .verticalScroll(rememberScrollState())
+    ) {
+        ChequingAccountCard()
+    }
+}
+
+@Composable
+fun ChequingAccountCard() {
+
+    val chequingAccount: Account? = chequingAccounts.find { it.number == 12345 }
+    val balance = chequingAccount?.balance
+
+    Card (
+        modifier = Modifier
+            .padding(13.dp)
+            .fillMaxWidth()
+    ) {
+        Text(
+            text = "Chequing",
+            style = MaterialTheme.typography.displaySmall
+        )
+        Text(
+            text = "$$balance",
+            style = MaterialTheme.typography.displayLarge
+        )
+        TextButton(
+            modifier = Modifier
+                .fillMaxWidth(),
+            onClick = { /*TODO*/ }
+        ) {
+            Text(
+                text = "VIEW",
+                style = MaterialTheme.typography.titleLarge
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun OverviewScreenPreview()
+{
+    OverviewScreen()
+}
+
+@Preview
+@Composable
+fun ChocolateShopDarkModePreview() {
+    EmptyActivityTheme(darkTheme = true) {
+        OverviewScreen()
+    }
+}

--- a/app/src/main/java/com/example/emptyactivity/components/BankTabRow.kt
+++ b/app/src/main/java/com/example/emptyactivity/components/BankTabRow.kt
@@ -1,0 +1,81 @@
+package com.example.emptyactivity.components
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.emptyactivity.BankDestination
+import java.util.Locale
+
+/**
+ * Date of Retrieval: 2023/11/02
+ * All Tab-related functions and variables are based on the ones in the Rally app from the Navigation codelab.
+ * https://developer.android.com/codelabs/jetpack-compose-navigation
+ */
+@Composable
+fun BankTabRow(
+    screens: List<BankDestination>,
+    onTabSelected: (BankDestination) -> Unit,
+    currentScreen: BankDestination
+) {
+    Surface(
+        Modifier
+            .fillMaxWidth()
+            .height(64.dp)
+    ) {
+        Row(Modifier.selectableGroup()) {
+            screens.forEach { screen ->
+                BankTab(
+                    text = screen.route,
+                    onSelected = { onTabSelected(screen) },
+                    selected = currentScreen == screen
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BankTab(
+    text: String,
+    onSelected: () -> Unit,
+    selected: Boolean
+) {
+    Row(
+        modifier = Modifier
+            .padding(13.dp)
+            .height(64.dp)
+            .selectable(
+                selected = selected,
+                onClick = onSelected,
+                role = Role.Tab,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(
+                    bounded = false,
+                    radius = Dp.Unspecified,
+                    color = Color.Unspecified
+                )
+            )
+            .clearAndSetSemantics { contentDescription = text }
+    ) {
+        Spacer(Modifier.width(10.dp))
+        Text(text.uppercase(Locale.getDefault()))
+    }
+}

--- a/app/src/main/java/com/example/emptyactivity/data/BankData.kt
+++ b/app/src/main/java/com/example/emptyactivity/data/BankData.kt
@@ -4,6 +4,7 @@ data class Account(
     val name: String,
     val number: Int,
     val balance: Double,
+    var transactions: MutableList<Transaction>,
     var dueDate: String? = null
 )
 
@@ -14,12 +15,15 @@ data class Transaction(
     val subtotal: Double
 )
 
-var chequingTransactions = listOf(
-    Transaction("2023-10-18", -23.00, "McDonald's", 1234.00),
-    Transaction("2023-10-11", -7.00, "Couche-Tard", 1257.00),
-    Transaction("2023-10-04", 500.00, "Transfer", 1264.00),
-    Transaction("2023-09-27", -14.00, "Uniprix", 764.00),
-    Transaction("2023-09-20", -46.00, "Gym", 778.00)
+var chequingAccounts = listOf(
+    Account("Chequing", 12345, 1234.00, mutableListOf(
+            Transaction("2023-10-18", -23.00, "McDonald's", 1234.00),
+            Transaction("2023-10-11", -7.00, "Couche-Tard", 1257.00),
+            Transaction("2023-10-04", 500.00, "Transfer", 1264.00),
+            Transaction("2023-09-27", -14.00, "Uniprix", 764.00),
+            Transaction("2023-09-20", -46.00, "Gym", 778.00)
+        )
+    )
 )
 
 var savingsTransactions = listOf(

--- a/app/src/main/java/com/example/emptyactivity/data/BankData.kt
+++ b/app/src/main/java/com/example/emptyactivity/data/BankData.kt
@@ -1,0 +1,37 @@
+package com.example.emptyactivity.data
+
+data class Account(
+    val name: String,
+    val number: Int,
+    val balance: Double,
+    var dueDate: String? = null
+)
+
+data class Transaction(
+    val date: String,
+    val amount: Double,
+    val detail: String,
+    val subtotal: Double
+)
+
+var chequingTransactions = listOf(
+    Transaction("2023-10-18", -23.00, "McDonald's", 1234.00),
+    Transaction("2023-10-11", -7.00, "Couche-Tard", 1257.00),
+    Transaction("2023-10-04", 500.00, "Transfer", 1264.00),
+    Transaction("2023-09-27", -14.00, "Uniprix", 764.00),
+    Transaction("2023-09-20", -46.00, "Gym", 778.00)
+)
+
+var savingsTransactions = listOf(
+    Transaction("2023-10-18", 20.00, "Interest", 6789.00),
+    Transaction("2023-10-11", -70.00, "Transfer", 6769.00),
+    Transaction("2023-10-04", 20.00, "Interest", 6839.00),
+    Transaction("2023-09-27", 400.00, "Deposit", 6819.00),
+    Transaction("2023-09-20", 20.00, "Interest", 6419.00)
+)
+
+var creditTransactions = listOf(
+    Transaction("2023-10-18", 549.00, "Rent", 999.00),
+    Transaction("2023-10-11", 50.00, "GazMetro", 450.00),
+    Transaction("2023-09-27", 400.00, "Tuition", 400.00)
+)


### PR DESCRIPTION
### Pull Request Description

What task/requirement is this resolving (link):

- [Summarize banking info in OverviewScreen](https://github.com/AppDevOrganization/5A6-group-project/issues/31)
- [Add Navigation to the bank app](https://github.com/AppDevOrganization/5A6-group-project/issues/33)

Resolution description:

- Card for the Chequing Account information was added.
- Navigation dependency added, enabling switching between different screens.

Level of Effort (Update from Estimate):

8

### Code Checklist
- [x] tested
- [x] linted
- [x] reviewed

![Image](https://i.ibb.co/FmYHWtY/chequing-overview.png)